### PR TITLE
Contracts: Fix multiple methods

### DIFF
--- a/contracts/ERC4626Adapter.sol
+++ b/contracts/ERC4626Adapter.sol
@@ -16,6 +16,8 @@ pragma solidity ^0.8.0;
 
 import '@openzeppelin/contracts/access/Ownable.sol';
 import '@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol';
+import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+import '@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol';
 
 import '@mimic-fi/v3-helpers/contracts/math/FixedPoint.sol';
 import '@mimic-fi/v3-helpers/contracts/utils/ERC20Helpers.sol';
@@ -26,7 +28,7 @@ import './interfaces/IERC4626Adapter.sol';
  * @title ERC4626 adapter
  * @dev Adapter used to track the accounting of investments made through ERC4626 implementations
  */
-contract ERC4626Adapter is IERC4626Adapter, ERC4626, Ownable {
+contract ERC4626Adapter is IERC4626Adapter, ERC4626, Ownable, Initializable, ReentrancyGuardUpgradeable {
     using FixedPoint for uint256;
 
     // Reference to the ERC4626 contract
@@ -56,13 +58,96 @@ contract ERC4626Adapter is IERC4626Adapter, ERC4626, Ownable {
         _setFeePct(_feePct);
         _setFeeCollector(_feeCollector);
         _transferOwnership(owner);
+        _disableInitializers();
+    }
+
+    /**
+     * @dev Initializes the ERC4626 adapter
+     */
+    function initialize() external virtual initializer {
+        __ReentrancyGuard_init();
     }
 
     /**
      * @dev Tells the total amount of assets
      */
     function totalAssets() public view override(IERC4626, ERC4626) returns (uint256) {
-        return erc4626.maxWithdraw(address(this));
+        return erc4626.convertToAssets(erc4626.balanceOf(address(this)));
+    }
+
+    /**
+     * @dev Tells the maximum amount of assets that can be withdrawn from an owner balance
+     */
+    function maxWithdraw(address owner) public view virtual override(IERC4626, ERC4626) returns (uint256) {
+        return Math.min(super.maxWithdraw(owner), erc4626.maxWithdraw(address(this)));
+    }
+
+    /**
+     * @dev Tells the maximum amount of shares that can be redeemed from an owner balance
+     */
+    function maxRedeem(address owner) public view virtual override(IERC4626, ERC4626) returns (uint256) {
+        return _convertToShares(maxWithdraw(owner), Math.Rounding.Down);
+    }
+
+    /**
+     * @dev Deposits assets
+     * @param assets Amount of assets to be deposited
+     * @param receiver Address that will receive the shares
+     *
+     * Note: overrides the standard in order to add the `nonReentrant` modifier
+     */
+    function deposit(uint256 assets, address receiver)
+        public
+        override(IERC4626, ERC4626)
+        nonReentrant
+        returns (uint256)
+    {
+        return super.deposit(assets, receiver);
+    }
+
+    /**
+     * @dev Mints shares
+     * @param shares Amount of shares to be minted
+     * @param receiver Address that will receive the shares
+     *
+     * Note: overrides the standard in order to add the `nonReentrant` modifier
+     */
+    function mint(uint256 shares, address receiver) public override(IERC4626, ERC4626) nonReentrant returns (uint256) {
+        return super.mint(shares, receiver);
+    }
+
+    /**
+     * @dev Withdraws assets
+     * @param assets Amount of assets to be withdrawn
+     * @param receiver Address that will receive the assets
+     * @param owner Address that owns the shares
+     *
+     * Note: overrides the standard in order to add the `nonReentrant` modifier
+     */
+    function withdraw(uint256 assets, address receiver, address owner)
+        public
+        override(IERC4626, ERC4626)
+        nonReentrant
+        returns (uint256)
+    {
+        return super.withdraw(assets, receiver, owner);
+    }
+
+    /**
+     * @dev Redeems shares
+     * @param shares Amount of shares to be redeemed
+     * @param receiver Address that will receive the assets
+     * @param owner Address that owns the shares
+     *
+     * Note: overrides the standard in order to add the `nonReentrant` modifier
+     */
+    function redeem(uint256 shares, address receiver, address owner)
+        public
+        override(IERC4626, ERC4626)
+        nonReentrant
+        returns (uint256)
+    {
+        return super.redeem(shares, receiver, owner);
     }
 
     /**
@@ -84,6 +169,9 @@ contract ERC4626Adapter is IERC4626Adapter, ERC4626, Ownable {
      * @param pct Fee percentage to be set
      */
     function setFeePct(uint256 pct) external override onlyOwner {
+        _settleFees();
+        previousTotalAssets = totalAssets();
+
         _setFeePct(pct);
     }
 
@@ -92,6 +180,9 @@ contract ERC4626Adapter is IERC4626Adapter, ERC4626, Ownable {
      * @param collector Fee collector to be set
      */
     function setFeeCollector(address collector) external override onlyOwner {
+        _settleFees();
+        previousTotalAssets = totalAssets();
+
         _setFeeCollector(collector);
     }
 
@@ -135,7 +226,7 @@ contract ERC4626Adapter is IERC4626Adapter, ERC4626, Ownable {
      * @param receiver Address that will receive the assets
      * @param owner Address that owns the shares
      * @param assets Amount of assets to be withdrawn
-     * @param shares Amount of shares to be burnt
+     * @param shares Amount of shares to be redeemed
      */
     function _withdraw(address caller, address receiver, address owner, uint256 assets, uint256 shares)
         internal
@@ -173,6 +264,7 @@ contract ERC4626Adapter is IERC4626Adapter, ERC4626, Ownable {
      */
     function _settleFees() internal {
         uint256 feeAmount = _pendingFeesInShareValue();
+        if (feeAmount == 0) return;
         _mint(feeCollector, feeAmount);
         emit FeesSettled(feeCollector, feeAmount);
     }

--- a/contracts/test/mocks/ERC4626Mock.sol
+++ b/contracts/test/mocks/ERC4626Mock.sol
@@ -4,11 +4,23 @@ pragma solidity ^0.8.0;
 import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol';
 
-contract ERC4626Mock is ERC4626 {
-    constructor(address underlying) ERC20('ERC4626Mock', 'E4626M') ERC4626(IERC20Metadata(underlying)) {}
+import '@mimic-fi/v3-helpers/contracts/math/FixedPoint.sol';
 
-    function mint(address account, uint256 amount) external {
-        _mint(account, amount);
+contract ERC4626Mock is ERC4626 {
+    using FixedPoint for uint256;
+
+    // Used to simulate the total supply is not fully available
+    uint256 public immutable factor;
+
+    constructor(address underlying, uint256 _factor)
+        ERC20('ERC4626Mock', 'E4626M')
+        ERC4626(IERC20Metadata(underlying))
+    {
+        factor = _factor;
+    }
+
+    function maxWithdraw(address owner) public view override returns (uint256) {
+        return super.maxWithdraw(owner).mulDown(factor);
     }
 
     function burn(address account, uint256 amount) external {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "@mimic-fi/v3-helpers": "0.1.0",
-    "@openzeppelin/contracts": "4.9.3"
+    "@openzeppelin/contracts": "4.9.3",
+    "@openzeppelin/contracts-upgradeable": "4.9.3"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.2.3",
@@ -43,6 +44,8 @@
   },
   "eslintConfig": {
     "extends": "eslint-config-mimic",
-    "ignorePatterns": ["dist"]
+    "ignorePatterns": [
+      "dist"
+    ]
   }
 }

--- a/test/ERC4626Adapter.test.ts
+++ b/test/ERC4626Adapter.test.ts
@@ -1,6 +1,7 @@
 import {
   assertAlmostEqual,
   assertEvent,
+  assertNoEvent,
   bn,
   deploy,
   deployTokenMock,
@@ -29,7 +30,7 @@ describe('ERC4626 Adapter', () => {
 
   before('create token and erc4626', async () => {
     token = await deployTokenMock('TKN')
-    erc4626Mock = await deploy('ERC4626Mock', [token.address])
+    erc4626Mock = await deploy('ERC4626Mock', [token.address, 1])
   })
 
   before('create erc4626 adapter', async () => {
@@ -53,6 +54,14 @@ describe('ERC4626 Adapter', () => {
       it('inherits decimals from asset', async () => {
         expect(await erc4626Adapter.decimals()).to.be.equal(await token.decimals())
       })
+
+      it('sets the owner correctly', async () => {
+        expect(await erc4626Adapter.owner()).to.be.equal(owner.address)
+      })
+
+      it('cannot be initialized twice', async () => {
+        await expect(erc4626Adapter.initialize()).to.be.revertedWith('Initializable: contract is already initialized')
+      })
     })
 
     context('when the fee percentage is above 1', () => {
@@ -68,19 +77,71 @@ describe('ERC4626 Adapter', () => {
 
   describe('setFeeCollector', () => {
     context('when the sender is authorized', () => {
+      beforeEach('create token and erc4626', async () => {
+        token = await deployTokenMock('TKN')
+        erc4626Mock = await deploy('ERC4626Mock', [token.address, 1])
+      })
+
+      beforeEach('create erc4626 adapter', async () => {
+        erc4626Adapter = await deploy('ERC4626Adapter', [erc4626Mock.address, fee, collector.address, owner.address])
+      })
+
       beforeEach('set sender', () => {
         erc4626Adapter = erc4626Adapter.connect(owner)
       })
 
       context('when the new collector is not zero', () => {
-        const newCollector = '0x0000000000000000000000000000000000000001'
+        const amount = fp(100)
 
-        it('sets the fee collector', async () => {
-          const tx = await erc4626Adapter.setFeeCollector(newCollector)
+        beforeEach('mint tokens', async () => {
+          await token.mint(other.address, fp(10000))
+        })
 
-          await assertEvent(tx, 'FeeCollectorSet', { collector: newCollector })
+        beforeEach('deposit 100 assets for other', async () => {
+          await token.connect(other).approve(erc4626Adapter.address, amount)
+          await erc4626Adapter.connect(other).deposit(amount, other.address)
+        })
 
-          expect(await erc4626Adapter.feeCollector()).to.be.equal(newCollector)
+        const itSetsFeeCollectorProperly = async (pendingFees: boolean) => {
+          const newCollector = '0x0000000000000000000000000000000000000001'
+
+          it('sets the fee collector', async () => {
+            const tx = await erc4626Adapter.setFeeCollector(newCollector)
+
+            await assertEvent(tx, 'FeeCollectorSet', { collector: newCollector })
+
+            expect(await erc4626Adapter.feeCollector()).to.be.equal(newCollector)
+          })
+
+          if (pendingFees) {
+            it('settles fees', async () => {
+              const tx = await erc4626Adapter.setFeeCollector(newCollector)
+
+              await assertEvent(tx, 'FeesSettled')
+            })
+          } else {
+            it('does not settle fees', async () => {
+              const tx = await erc4626Adapter.setFeeCollector(newCollector)
+
+              await assertNoEvent(tx, 'FeesSettled')
+            })
+          }
+        }
+
+        context('when there are pending fees', () => {
+          beforeEach('duplicate assets', async () => {
+            await token.mint(erc4626Mock.address, amount)
+          })
+
+          const pendingFees = true
+
+          itSetsFeeCollectorProperly(pendingFees)
+        })
+
+        context('when there are no pending fees', () => {
+          const pendingFees = false
+
+          itSetsFeeCollectorProperly(pendingFees)
         })
       })
 
@@ -108,20 +169,72 @@ describe('ERC4626 Adapter', () => {
 
   describe('setFeePct', () => {
     context('when the sender is authorized', () => {
+      beforeEach('create token and erc4626', async () => {
+        token = await deployTokenMock('TKN')
+        erc4626Mock = await deploy('ERC4626Mock', [token.address, 1])
+      })
+
+      beforeEach('create erc4626 adapter', async () => {
+        erc4626Adapter = await deploy('ERC4626Adapter', [erc4626Mock.address, fee, collector.address, owner.address])
+      })
+
       beforeEach('set sender', () => {
         erc4626Adapter = erc4626Adapter.connect(owner)
       })
 
       context('when the new fee pct is below the previous one', () => {
         context('when the new fee pct is not zero', () => {
-          const newFeePct = fee.sub(1)
+          const amount = fp(100)
 
-          it('sets the fee percentage', async () => {
-            const tx = await erc4626Adapter.setFeePct(newFeePct)
+          beforeEach('mint tokens', async () => {
+            await token.mint(other.address, fp(10000))
+          })
 
-            await assertEvent(tx, 'FeePctSet', { pct: newFeePct })
+          beforeEach('deposit 100 assets for other', async () => {
+            await token.connect(other).approve(erc4626Adapter.address, amount)
+            await erc4626Adapter.connect(other).deposit(amount, other.address)
+          })
 
-            expect(await erc4626Adapter.feePct()).to.be.equal(newFeePct)
+          const itSetsFeePctProperly = async (pendingFees: boolean) => {
+            const newFeePct = fee.sub(1)
+
+            it('sets the fee percentage', async () => {
+              const tx = await erc4626Adapter.setFeePct(newFeePct)
+
+              await assertEvent(tx, 'FeePctSet', { pct: newFeePct })
+
+              expect(await erc4626Adapter.feePct()).to.be.equal(newFeePct)
+            })
+
+            if (pendingFees) {
+              it('settles fees', async () => {
+                const tx = await erc4626Adapter.setFeePct(newFeePct)
+
+                await assertEvent(tx, 'FeesSettled')
+              })
+            } else {
+              it('does not settle fees', async () => {
+                const tx = await erc4626Adapter.setFeePct(newFeePct)
+
+                await assertNoEvent(tx, 'FeesSettled')
+              })
+            }
+          }
+
+          context('when there are pending fees', () => {
+            beforeEach('duplicate assets', async () => {
+              await token.mint(erc4626Mock.address, amount)
+            })
+
+            const pendingFees = true
+
+            itSetsFeePctProperly(pendingFees)
+          })
+
+          context('when there are no pending fees', () => {
+            const pendingFees = false
+
+            itSetsFeePctProperly(pendingFees)
           })
         })
 
@@ -292,6 +405,13 @@ describe('ERC4626 Adapter', () => {
   describe('integration', async () => {
     let userA: SignerWithAddress, userB: SignerWithAddress, userC: SignerWithAddress
 
+    const calculateUserMaxWithdraw = async (userAddress: string) => {
+      const balance = await erc4626Adapter.balanceOf(userAddress)
+      const superMaxWithdraw = await erc4626Adapter.convertToAssets(balance)
+      const underlyingMaxWithdraw = await erc4626Mock.maxWithdraw(erc4626Adapter.address)
+      return bn(Math.min(superMaxWithdraw, underlyingMaxWithdraw))
+    }
+
     function checkStatus(status: {
       totalAssets: BigNumber
       shareValue: BigNumber
@@ -304,6 +424,7 @@ describe('ERC4626 Adapter', () => {
       totalShares: BigNumber
       previousTotalAssets: BigNumber
     }) {
+      let userAMaxWithdraw: BigNumber, userBMaxWithdraw: BigNumber, userCMaxWithdraw: BigNumber
       const ERROR = 1e-18
 
       it('updates total assets correctly', async () => {
@@ -358,6 +479,42 @@ describe('ERC4626 Adapter', () => {
         const actualPreviousTotalAssets = await erc4626Adapter.previousTotalAssets()
         assertAlmostEqual(actualPreviousTotalAssets, status.previousTotalAssets, ERROR)
       })
+
+      it('updates userA maximum withdraw correctly', async () => {
+        const actualMaxWithdraw = await erc4626Adapter.maxWithdraw(userA.address)
+        userAMaxWithdraw = await calculateUserMaxWithdraw(userA.address)
+        assertAlmostEqual(actualMaxWithdraw, userAMaxWithdraw, ERROR)
+      })
+
+      it('updates userA maximum redeem correctly', async () => {
+        const actualMaxRedeem = await erc4626Adapter.maxRedeem(userA.address)
+        const userAMaxRedeem = await erc4626Adapter.convertToShares(userAMaxWithdraw)
+        assertAlmostEqual(actualMaxRedeem, userAMaxRedeem, ERROR)
+      })
+
+      it('updates userB maximum withdraw correctly', async () => {
+        const actualMaxWithdraw = await erc4626Adapter.maxWithdraw(userB.address)
+        userBMaxWithdraw = await calculateUserMaxWithdraw(userB.address)
+        assertAlmostEqual(actualMaxWithdraw, userBMaxWithdraw, ERROR)
+      })
+
+      it('updates userB maximum redeem correctly', async () => {
+        const actualMaxRedeem = await erc4626Adapter.maxRedeem(userB.address)
+        const userBMaxRedeem = await erc4626Adapter.convertToShares(userBMaxWithdraw)
+        assertAlmostEqual(actualMaxRedeem, userBMaxRedeem, ERROR)
+      })
+
+      it('updates userC maximum withdraw correctly', async () => {
+        const actualMaxWithdraw = await erc4626Adapter.maxWithdraw(userC.address)
+        userCMaxWithdraw = await calculateUserMaxWithdraw(userC.address)
+        assertAlmostEqual(actualMaxWithdraw, userCMaxWithdraw, ERROR)
+      })
+
+      it('updates userC maximum redeem correctly', async () => {
+        const actualMaxRedeem = await erc4626Adapter.maxRedeem(userC.address)
+        const userCMaxRedeem = await erc4626Adapter.convertToShares(userCMaxWithdraw)
+        assertAlmostEqual(actualMaxRedeem, userCMaxRedeem, ERROR)
+      })
     }
 
     before('setup signers', async () => {
@@ -366,67 +523,57 @@ describe('ERC4626 Adapter', () => {
     })
 
     context('when the underlying erc4626 works as expected', async () => {
-      before('create token and erc4626', async () => {
-        token = await deployTokenMock('TKN')
-        await token.mint(userA.address, fp(10000))
-        await token.mint(userB.address, fp(10000))
-        await token.mint(userC.address, fp(10000))
-        erc4626Mock = await deploy('ERC4626Mock', [token.address])
-      })
+      const itWorksAsExpected = async () => {
+        context('when userA deposits 100 assets', async () => {
+          let totalAssets: BigNumber, shareValue: BigNumber, userAShares: BigNumber, userAAssets: BigNumber
+          let userBShares: BigNumber, userBAssets: BigNumber, userCShares: BigNumber, userCAssets: BigNumber
+          let totalShares: BigNumber, previousTotalAssets: BigNumber
 
-      before('create erc4626 adapter', async () => {
-        erc4626Adapter = await deploy('ERC4626Adapter', [erc4626Mock.address, fee, userC.address, owner.address])
-      })
+          const amount = fp(100)
 
-      context('when userA deposits 100 assets', async () => {
-        let totalAssets: BigNumber, shareValue: BigNumber, userAShares: BigNumber, userAAssets: BigNumber
-        let userBShares: BigNumber, userBAssets: BigNumber, userCShares: BigNumber, userCAssets: BigNumber
-        let totalShares: BigNumber, previousTotalAssets: BigNumber
+          const calculateUserAssets = (userShares: BigNumber) => {
+            return userShares.mul(shareValue).div(fp(1))
+          }
 
-        const amount = fp(100)
-
-        const calculateUserAssets = (userShares: BigNumber) => {
-          return userShares.mul(shareValue).div(fp(1))
-        }
-
-        before('deposit 100 assets for userA', async () => {
-          await token.connect(userA).approve(erc4626Adapter.address, amount)
-          await erc4626Adapter.connect(userA).deposit(amount, userA.address)
-        })
-
-        totalAssets = amount // 100
-        shareValue = fp(1)
-        userAShares = amount // 100
-        userAAssets = amount // 100
-        totalShares = amount // 100
-        previousTotalAssets = amount // 100
-
-        checkStatus({
-          totalAssets,
-          shareValue,
-          userAShares,
-          userAAssets,
-          userBShares: fp(0),
-          userBAssets: fp(0),
-          userCShares: fp(0),
-          userCAssets: fp(0),
-          totalShares,
-          previousTotalAssets,
-        })
-
-        context('when assets triplicate', async () => {
-          const amount = fp(200)
-
-          before('triplicate assets', async () => {
-            await token.mint(erc4626Mock.address, amount)
+          before('deposit 100 assets for userA', async () => {
+            await token.connect(userA).approve(erc4626Adapter.address, amount)
+            await erc4626Adapter.connect(userA).deposit(amount, userA.address)
           })
 
-          totalAssets = totalAssets.add(amount) // 300
-          shareValue = fp(2.8)
-          userAAssets = calculateUserAssets(userAShares) // 280
-          userCAssets = totalAssets.sub(previousTotalAssets).mul(fee).div(fp(1)) // 20
-          userCShares = userCAssets.mul(fp(1)).div(shareValue) // 7.14
-          ;(totalShares = totalShares.add(userCShares)), // 107.14
+          totalAssets = amount // 100
+          shareValue = fp(1)
+          userAShares = amount // 100
+          userAAssets = amount // 100
+          totalShares = amount // 100
+          previousTotalAssets = amount // 100
+
+          checkStatus({
+            totalAssets,
+            shareValue,
+            userAShares,
+            userAAssets,
+            userBShares: fp(0),
+            userBAssets: fp(0),
+            userCShares: fp(0),
+            userCAssets: fp(0),
+            totalShares,
+            previousTotalAssets,
+          })
+
+          context('when assets triplicate', async () => {
+            const amount = fp(200)
+
+            before('triplicate assets', async () => {
+              await token.mint(erc4626Mock.address, amount)
+            })
+
+            totalAssets = totalAssets.add(amount) // 300
+            shareValue = fp(2.8)
+            userAAssets = calculateUserAssets(userAShares) // 280
+            userCAssets = totalAssets.sub(previousTotalAssets).mul(fee).div(fp(1)) // 20
+            userCShares = userCAssets.mul(fp(1)).div(shareValue) // 7.14
+            totalShares = totalShares.add(userCShares) // 107.14
+
             checkStatus({
               totalAssets,
               shareValue,
@@ -440,47 +587,41 @@ describe('ERC4626 Adapter', () => {
               previousTotalAssets,
             })
 
-          context('when userB deposits 30 assets', async () => {
-            const amount = fp(30)
-
-            before('deposit 30 assets for userB', async () => {
-              await token.connect(userB).approve(erc4626Adapter.address, amount)
-              await erc4626Adapter.connect(userB).deposit(amount, userB.address)
-            })
-
-            totalAssets = totalAssets.add(amount) // 330
-            userBAssets = amount // 30
-            userBShares = amount.mul(fp(1)).div(shareValue) // 10.714
-            totalShares = totalShares.add(userBShares) // 117.854
-            previousTotalAssets = totalAssets // 330
-
-            checkStatus({
-              totalAssets,
-              shareValue,
-              userAShares,
-              userAAssets,
-              userBShares,
-              userBAssets,
-              userCShares,
-              userCAssets,
-              totalShares,
-              previousTotalAssets,
-            })
-
-            context('when assets duplicate', async () => {
-              const amount = fp(330)
-
-              before('duplicate assets', async () => {
-                await token.mint(erc4626Mock.address, amount)
+            context('when the fee collector changes', async () => {
+              before('set userB as fee collector', async () => {
+                await erc4626Adapter.connect(userA).setFeeCollector(userB.address)
               })
 
-              totalAssets = totalAssets.add(amount) // 660
-              shareValue = fp(5.32)
-              userAAssets = calculateUserAssets(userAShares) // 532
-              userBAssets = calculateUserAssets(userBShares) // 57
-              userCShares = userCShares.add(fp(33).mul(fp(1)).div(shareValue)) // 13.34
-              userCAssets = calculateUserAssets(userCShares) // 71
-              ;(totalShares = userAShares.add(userBShares).add(userCShares)), // 124.05
+              // There are fees to be settled, hence `previousTotalAssets` should be updated
+              previousTotalAssets = totalAssets // 300
+
+              checkStatus({
+                totalAssets,
+                shareValue,
+                userAShares,
+                userAAssets,
+                userBShares: fp(0),
+                userBAssets: fp(0),
+                userCShares,
+                userCAssets,
+                totalShares,
+                previousTotalAssets,
+              })
+
+              context('when userB deposits 30 assets', async () => {
+                const amount = fp(30)
+
+                before('deposit 30 assets for userB', async () => {
+                  await token.connect(userB).approve(erc4626Adapter.address, amount)
+                  await erc4626Adapter.connect(userB).deposit(amount, userB.address)
+                })
+
+                totalAssets = totalAssets.add(amount) // 330
+                userBAssets = amount // 30
+                userBShares = amount.mul(fp(1)).div(shareValue) // 10.714
+                totalShares = totalShares.add(userBShares) // 117.854
+                previousTotalAssets = totalAssets // 300
+
                 checkStatus({
                   totalAssets,
                   shareValue,
@@ -494,36 +635,145 @@ describe('ERC4626 Adapter', () => {
                   previousTotalAssets,
                 })
 
-              context('when userA withdraws 50 shares', async () => {
-                const amount = fp(50)
-                const assets = amount.mul(shareValue).div(fp(1))
+                context('when the fee percentage changes', async () => {
+                  before('set a new fee percentage', async () => {
+                    const newFee = fp(0.05)
+                    await erc4626Adapter.connect(userA).setFeePct(newFee)
+                  })
 
-                before('withdraw 50 shares for userA', async () => {
-                  await erc4626Adapter.connect(userA).redeem(amount, userA.address, userA.address)
-                })
+                  // There are no fees to be settled, hence everything remains the same
+                  checkStatus({
+                    totalAssets,
+                    shareValue,
+                    userAShares,
+                    userAAssets,
+                    userBShares,
+                    userBAssets,
+                    userCShares,
+                    userCAssets,
+                    totalShares,
+                    previousTotalAssets,
+                  })
 
-                totalAssets = totalAssets.sub(assets) // 394
-                userAAssets = userAAssets.sub(assets) // 266
-                userAShares = userAShares.sub(amount) // 50
-                totalShares = totalShares.sub(amount) // 74.05
-                previousTotalAssets = totalAssets // 394
+                  context('when assets duplicate', async () => {
+                    const amount = fp(330)
 
-                checkStatus({
-                  totalAssets,
-                  shareValue,
-                  userAShares,
-                  userAAssets,
-                  userBShares,
-                  userBAssets,
-                  userCShares,
-                  userCAssets,
-                  totalShares,
-                  previousTotalAssets,
+                    before('duplicate assets', async () => {
+                      await token.mint(erc4626Mock.address, amount)
+                    })
+
+                    totalAssets = totalAssets.add(amount) // 660
+                    shareValue = fp(5.46)
+                    userAAssets = calculateUserAssets(userAShares) // 546
+                    userBShares = userBShares.add(
+                      fp(33 / 2)
+                        .mul(fp(1))
+                        .div(shareValue)
+                    ) // 13.81
+                    userBAssets = calculateUserAssets(userBShares) // 73.5
+                    userCAssets = calculateUserAssets(userCShares) // 38
+                    totalShares = userAShares.add(userBShares).add(userCShares) // 120.95
+
+                    checkStatus({
+                      totalAssets,
+                      shareValue,
+                      userAShares,
+                      userAAssets,
+                      userBShares,
+                      userBAssets,
+                      userCShares,
+                      userCAssets,
+                      totalShares,
+                      previousTotalAssets,
+                    })
+
+                    context('when userA withdraws 50 shares', async () => {
+                      const amount = fp(50).sub(1)
+                      const assets = amount.mul(shareValue).div(fp(1))
+
+                      before('withdraw 50 shares for userA', async () => {
+                        await erc4626Adapter.connect(userA).redeem(amount, userA.address, userA.address)
+                      })
+
+                      totalAssets = totalAssets.sub(assets) // 387
+                      userAAssets = userAAssets.sub(assets) // 273
+                      userAShares = userAShares.sub(amount) // 50
+                      totalShares = totalShares.sub(amount) // 70.9
+                      previousTotalAssets = totalAssets // 387
+
+                      checkStatus({
+                        totalAssets,
+                        shareValue,
+                        userAShares,
+                        userAAssets,
+                        userBShares,
+                        userBAssets,
+                        userCShares,
+                        userCAssets,
+                        totalShares,
+                        previousTotalAssets,
+                      })
+                    })
+                  })
                 })
               })
             })
           })
         })
+      }
+
+      context('when the underlying protocol is liquid', async () => {
+        const FACTOR = fp(1) // all assets are available
+
+        before('create token and erc4626', async () => {
+          token = await deployTokenMock('TKN')
+          await token.mint(userA.address, fp(10000))
+          await token.mint(userB.address, fp(10000))
+          await token.mint(userC.address, fp(10000))
+          erc4626Mock = await deploy('ERC4626Mock', [token.address, FACTOR])
+        })
+
+        before('create erc4626 adapter', async () => {
+          erc4626Adapter = await deploy('ERC4626Adapter', [erc4626Mock.address, fee, userC.address, owner.address])
+        })
+
+        itWorksAsExpected()
+      })
+
+      context('when the underlying protocol is not liquid enough', async () => {
+        const FACTOR = fp(0.5) // half of the assets are available
+
+        before('create token and erc4626', async () => {
+          token = await deployTokenMock('TKN')
+          await token.mint(userA.address, fp(10000))
+          await token.mint(userB.address, fp(10000))
+          await token.mint(userC.address, fp(10000))
+          erc4626Mock = await deploy('ERC4626Mock', [token.address, FACTOR])
+        })
+
+        before('create erc4626 adapter', async () => {
+          erc4626Adapter = await deploy('ERC4626Adapter', [erc4626Mock.address, fee, userC.address, owner.address])
+        })
+
+        itWorksAsExpected()
+      })
+
+      context('when the underlying protocol has more assets available than the adapter', async () => {
+        const FACTOR = fp(2) // the double of the assets are available
+
+        before('create token and erc4626', async () => {
+          token = await deployTokenMock('TKN')
+          await token.mint(userA.address, fp(10000))
+          await token.mint(userB.address, fp(10000))
+          await token.mint(userC.address, fp(10000))
+          erc4626Mock = await deploy('ERC4626Mock', [token.address, FACTOR])
+        })
+
+        before('create erc4626 adapter', async () => {
+          erc4626Adapter = await deploy('ERC4626Adapter', [erc4626Mock.address, fee, userC.address, owner.address])
+        })
+
+        itWorksAsExpected()
       })
     })
 
@@ -534,7 +784,7 @@ describe('ERC4626 Adapter', () => {
         token = await deploy('TokenMock', ['TKN', 8])
         await token.mint(userA.address, fp(10000))
         await token.mint(userB.address, fp(10000))
-        erc4626Mock = await deploy('ERC4626Mock', [token.address])
+        erc4626Mock = await deploy('ERC4626Mock', [token.address, fp(1)])
       })
 
       beforeEach('create erc4626 adapter', async () => {
@@ -556,64 +806,131 @@ describe('ERC4626 Adapter', () => {
       })
 
       context('when assets are drained', async () => {
-        const itWorksAsExpected = (drainAmount: BigNumber, maxWithdrawAmount: BigNumber, fee: BigNumberish) => {
-          beforeEach('drain assets', async () => {
-            await token.burn(erc4626Mock.address, drainAmount)
-          })
-
-          context('when userA withdraws the assets left', async () => {
-            const amount = maxWithdrawAmount
-
-            it('lets users withdraw all their assets left', async () => {
-              const previousBalance = await token.balanceOf(userA.address)
-
-              await erc4626Adapter.connect(userA).withdraw(amount, userA.address, userA.address)
-
-              const currentBalance = await token.balanceOf(userA.address)
-              expect(currentBalance).to.be.equal(previousBalance.add(amount))
-
-              await expect(erc4626Adapter.connect(userB).withdraw(amount, userB.address, userB.address)).not.to.be
-                .reverted
+        context('when assets are drained before fees are settled', async () => {
+          const itWorksAsExpected = (drainAmount: BigNumber, maxWithdrawAmount: BigNumber, fee: BigNumberish) => {
+            beforeEach('drain assets', async () => {
+              await token.burn(erc4626Mock.address, drainAmount)
             })
 
-            it(`${fee ? 'charges a fee' : 'does not charge any fee'}`, async () => {
-              const tx = await erc4626Adapter.connect(userA).withdraw(amount, userA.address, userA.address)
+            context('when userA withdraws the assets left', async () => {
+              const amount = maxWithdrawAmount
 
-              await assertEvent(tx, 'FeesSettled', { collector: userC.address, amount: fee })
+              it('lets users withdraw all their assets left', async () => {
+                const previousBalance = await token.balanceOf(userA.address)
+
+                await erc4626Adapter.connect(userA).withdraw(amount, userA.address, userA.address)
+
+                const currentBalance = await token.balanceOf(userA.address)
+                expect(currentBalance).to.be.equal(previousBalance.add(amount))
+
+                await expect(erc4626Adapter.connect(userB).withdraw(amount, userB.address, userB.address)).not.to.be
+                  .reverted
+              })
+
+              if (fee) {
+                it('charges a fee', async () => {
+                  const tx = await erc4626Adapter.connect(userA).withdraw(amount, userA.address, userA.address)
+
+                  await assertEvent(tx, 'FeesSettled', { collector: userC.address, amount: fee })
+                })
+              } else {
+                it('does not charge any fee', async () => {
+                  const tx = await erc4626Adapter.connect(userA).withdraw(amount, userA.address, userA.address)
+
+                  await assertNoEvent(tx, 'FeesSettled')
+                })
+              }
             })
+
+            context('when userA withdraws more than the assets left', async () => {
+              it('reverts', async () => {
+                const amount = maxWithdrawAmount.add(1)
+
+                await expect(erc4626Adapter.connect(userA).withdraw(amount, userA.address, userA.address)).to.be
+                  .reverted
+              })
+            })
+          }
+
+          context('when there is a loss', async () => {
+            const drainAmount = fp(500)
+            const maxWithdrawAmount = fp(50)
+            const fee = 0
+
+            itWorksAsExpected(drainAmount, maxWithdrawAmount, fee)
           })
 
-          context('when userA withdraws more than the assets left', async () => {
-            it('reverts', async () => {
-              const amount = maxWithdrawAmount.add(1)
+          context('when there is a breakeven', async () => {
+            const drainAmount = fp(400)
+            const maxWithdrawAmount = initialAmount
+            const fee = 0
 
-              await expect(erc4626Adapter.connect(userA).withdraw(amount, userA.address, userA.address)).to.be.reverted
-            })
+            itWorksAsExpected(drainAmount, maxWithdrawAmount, fee)
           })
-        }
 
-        context('when there is a loss', async () => {
-          const drainAmount = fp(500)
-          const maxWithdrawAmount = fp(50)
-          const fee = 0
+          context('when there is still some profit', async () => {
+            const drainAmount = fp(200)
+            const maxWithdrawAmount = fp(190).sub(1) // because of rounding when charging fees
+            const fee = bn('10526315789473684210') // 10 shares = 20 assets
 
-          itWorksAsExpected(drainAmount, maxWithdrawAmount, fee)
+            itWorksAsExpected(drainAmount, maxWithdrawAmount, fee)
+          })
         })
 
-        context('when there is a breakeven', async () => {
-          const drainAmount = fp(400)
-          const maxWithdrawAmount = initialAmount
-          const fee = 0
+        context('when assets are drained after fees were settled', async () => {
+          beforeEach('withdraw userA amount invested plus gains', async () => {
+            const maxWithdrawAmountBeforeDrain = fp(280).sub(1) // gain = 200, fee = 20
 
-          itWorksAsExpected(drainAmount, maxWithdrawAmount, fee)
-        })
+            await erc4626Adapter.connect(userA).withdraw(maxWithdrawAmountBeforeDrain, userA.address, userA.address)
+          })
 
-        context('when there is still some profit', async () => {
-          const drainAmount = fp(200)
-          const maxWithdrawAmount = fp(190).sub(1) // because of rounding when charging fees
-          const fee = bn('10526315789473684210') // 10 shares = 20 assets
+          context('when there is still some profit', async () => {
+            let collectorAssetsBeforeDrain: BigNumber
 
-          itWorksAsExpected(drainAmount, maxWithdrawAmount, fee)
+            const drainAmount = fp(100)
+            const fee = bn('14285714285714285713') // 14 shares = 40 assets (before draining)
+            const maxWithdrawAmountAfterDrain = fp(192.5) // 100 shares = 192.5 assets (after draining)
+
+            beforeEach('drain 100 assets', async () => {
+              collectorAssetsBeforeDrain = await erc4626Adapter.convertToAssets(fee)
+
+              await token.burn(erc4626Mock.address, drainAmount)
+            })
+
+            context('when userB withdraws the assets left', async () => {
+              it('lets users withdraw all their assets left', async () => {
+                // collector = 14 shares = 40 assets (before draining)
+                assertAlmostEqual(collectorAssetsBeforeDrain, fp(40), 1e-10)
+
+                // userB = 100 shares = 280 assets (before draining)
+                // userB = 100 shares = 220 * 280/320 = 192.5 assets (after draining)
+                await expect(
+                  erc4626Adapter.connect(userB).withdraw(maxWithdrawAmountAfterDrain, userB.address, userB.address)
+                ).not.to.be.reverted
+
+                // collector = 14 shares = 220 * 40/320 = 27.5 assets (after draining)
+                const collectorAssetsAfterDrain = await erc4626Adapter.convertToAssets(fee)
+                assertAlmostEqual(collectorAssetsAfterDrain, fp(27.5), 1e-10)
+              })
+
+              it('does not charge any other fee', async () => {
+                const tx = await erc4626Adapter
+                  .connect(userB)
+                  .withdraw(maxWithdrawAmountAfterDrain, userB.address, userB.address)
+
+                await assertNoEvent(tx, 'FeesSettled')
+              })
+            })
+
+            context('when userB withdraws more than the assets left', async () => {
+              it('reverts', async () => {
+                const amount = maxWithdrawAmountAfterDrain.add(1)
+
+                await expect(erc4626Adapter.connect(userB).withdraw(amount, userB.address, userB.address)).to.be
+                  .reverted
+              })
+            })
+          })
         })
       })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1195,6 +1195,11 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
+"@openzeppelin/contracts-upgradeable@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.3.tgz#ff17a80fb945f5102571f8efecb5ce5915cc4811"
+  integrity sha512-jjaHAVRMrE4UuZNfDwjlLGDxTHWIOwTJS2ldnc278a0gevfXfPr8hxKEVBGFBE96kl2G3VHDZhUimw/+G3TG2A==
+
 "@openzeppelin/contracts@4.9.3":
   version "4.9.3"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.3.tgz#00d7a8cf35a475b160b3f0293a6403c511099364"


### PR DESCRIPTION
This PR:

1. Overrides `maxWithdraw` and `maxRedeem` methods
2. Adds `nonReentrant` modifier to non view inherited methods
3. Fixes `totalSupply` method
4. Implements fee settlement in `setFeeCollector` and `setFeePct` methods
5. Tests additional loss cases
6. Prevents minting shares when pending fees are 0