### PR TITLE
Contract: Apply code review suggestions

### DIFF
--- a/contracts/interfaces/IERC4626Adapter.sol
+++ b/contracts/interfaces/IERC4626Adapter.sol
@@ -106,7 +106,7 @@ interface IERC4626Adapter is IERC4626 {
     function pendingFeesInShares() external view returns (uint256);
 
     /**
-     * @dev Sets the fee percentage
+     * @dev Sets the fee percentage. Note it cannot be increased.
      * @param pct Fee percentage to be set
      */
     function setFeePct(uint256 pct) external;
@@ -118,7 +118,7 @@ interface IERC4626Adapter is IERC4626 {
     function setFeeCollector(address collector) external;
 
     /**
-     * @dev Withdraw ERC20 tokens to an external account. To be used in order to withdraw claimed protocol rewards.
+     * @dev Withdraws ERC20 or native tokens to an external account. To be used in order to withdraw claimed protocol rewards.
      * @param token Address of the token to be withdrawn
      * @param recipient Address where the tokens will be transferred to
      * @param amount Amount of tokens to withdraw

--- a/test/ERC4626Adapter.test.ts
+++ b/test/ERC4626Adapter.test.ts
@@ -58,6 +58,18 @@ describe('ERC4626 Adapter', () => {
       it('sets the owner correctly', async () => {
         expect(await erc4626Adapter.owner()).to.be.equal(owner.address)
       })
+
+      it('sets the name correctly', async () => {
+        const name = 'ERC4626 Adapter' + (await token.name())
+
+        expect(await erc4626Adapter.name()).to.be.equal(name)
+      })
+
+      it('sets the symbol correctly', async () => {
+        const symbol = 'erc4626adapter' + (await token.symbol())
+
+        expect(await erc4626Adapter.symbol()).to.be.equal(symbol)
+      })
     })
 
     context('when the fee percentage is above 1', () => {


### PR DESCRIPTION
This PR:
- Adds the `nonReentrant` modifier to `setFeePct`, `setFeeCollector` and `rescueFunds` functions
- Provides explanation about how fees are calculated
- Renames `owner` parameters as `account`
- Provides explanation about how `_settleFees` should be called
- Appends a prefix to ERC20's `name` and `symbol`
- Adds minor comments related to `_setFeePct` and `rescueFunds` functions